### PR TITLE
Profile, PublicUser e Follow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,4 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 .idea/
 db.sqlite3
+*/migrations

--- a/posts/models/post.py
+++ b/posts/models/post.py
@@ -1,12 +1,16 @@
 import uuid
 from django.db import models
+from django.contrib.auth import get_user_model
+
+User = get_user_model()
+
 
 class Post(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
-    username = models.CharField(max_length=36, blank=False)
+    author = models.ForeignKey(User, on_delete=models.CASCADE, related_name='posts')
     content = models.CharField(max_length=255, blank=False)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 
     def __str__(self):
-        return f'{self.username} - {self.id}'
+        return f'{self.author.username} - {self.id}'

--- a/userdata/apps.py
+++ b/userdata/apps.py
@@ -4,3 +4,6 @@ from django.apps import AppConfig
 class UserdataConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'userdata'
+
+    def ready(self):
+        import userdata.signals

--- a/userdata/models.py
+++ b/userdata/models.py
@@ -1,3 +1,0 @@
-from django.db import models
-
-# Create your models here.

--- a/userdata/models/__init__.py
+++ b/userdata/models/__init__.py
@@ -1,0 +1,1 @@
+from .profile import Profile

--- a/userdata/models/profile.py
+++ b/userdata/models/profile.py
@@ -1,0 +1,17 @@
+from django.db import models
+from django.contrib.auth import get_user_model
+
+User = get_user_model()
+
+
+class Profile(models.Model):
+    user = models.OneToOneField(User, on_delete=models.CASCADE, related_name='profile')
+    name = models.CharField(max_length=40, blank=True, null=True)
+    avatar = models.TextField(blank=True, null=True)
+    cover = models.TextField(blank=True, null=True)
+    bio = models.TextField(blank=True)
+    birthdate = models.DateField(blank=True, null=True)
+    following = models.ManyToManyField('self', symmetrical=False, related_name='followers', blank=True)
+
+    def __str__(self):
+        return f'Perfil de {self.user.username}'

--- a/userdata/serializers/__init__.py
+++ b/userdata/serializers/__init__.py
@@ -1,2 +1,4 @@
 from .register_serializer import RegisterSerializer
 from .user_serializer import UserSerializer
+from .public_user_serializer import PublicUserSerializer
+from .profile_serializer import ProfileSerializer

--- a/userdata/serializers/profile_serializer.py
+++ b/userdata/serializers/profile_serializer.py
@@ -3,6 +3,15 @@ from ..models import Profile
 
 
 class ProfileSerializer(serializers.ModelSerializer):
+    following = serializers.SerializerMethodField()
+    followers = serializers.SerializerMethodField()
+
     class Meta:
         model = Profile
         fields = ['avatar', 'bio', 'birthdate', 'cover', 'name', 'following', 'followers']
+
+    def get_following(self, obj):
+        return [profile.user.username for profile in obj.following.all()]
+
+    def get_followers(self, obj):
+        return [profile.user.username for profile in obj.followers.all()]

--- a/userdata/serializers/profile_serializer.py
+++ b/userdata/serializers/profile_serializer.py
@@ -1,0 +1,8 @@
+from rest_framework import serializers
+from ..models import Profile
+
+
+class ProfileSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Profile
+        fields = ['avatar', 'bio', 'birthdate', 'cover', 'name', 'following', 'followers']

--- a/userdata/serializers/public_user_serializer.py
+++ b/userdata/serializers/public_user_serializer.py
@@ -1,0 +1,14 @@
+from rest_framework import serializers
+from django.contrib.auth import get_user_model
+
+from .profile_serializer import ProfileSerializer
+
+User = get_user_model()
+
+
+class PublicUserSerializer(serializers.ModelSerializer):
+    profile = ProfileSerializer(read_only=True)
+
+    class Meta:
+        model = User
+        fields = ['username', 'profile']

--- a/userdata/serializers/register_serializer.py
+++ b/userdata/serializers/register_serializer.py
@@ -7,7 +7,7 @@ class RegisterSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = User
-        fields = ['username', 'email', 'password']
+        fields = ['email', 'username', 'password']
 
     def create(self, validated_data):
         user = User.objects.create_user(

--- a/userdata/serializers/user_serializer.py
+++ b/userdata/serializers/user_serializer.py
@@ -6,3 +6,4 @@ class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
         fields = ['id', 'username', 'email']
+        read_only_fields = ['id']

--- a/userdata/signals.py
+++ b/userdata/signals.py
@@ -1,0 +1,12 @@
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+from django.contrib.auth import get_user_model
+from .models import Profile
+
+User = get_user_model()
+
+
+@receiver(post_save, sender=User)
+def created_profile(sender, instance, created, **kwargs):
+    if created:
+        Profile.objects.create(user=instance)

--- a/userdata/urls.py
+++ b/userdata/urls.py
@@ -1,7 +1,11 @@
 from django.urls import path
-from .viewsets import RegisterUsers, MeViewset
+from .viewsets import RegisterUsers, MeViewset, PublicUserViewset
+from .viewsets.follow import follow_user, unfollow_user
 
 urlpatterns = [
     path('register/', RegisterUsers.as_view(), name='register'),
-    path('me/', MeViewset.as_view(), name='me')
+    path('me/', MeViewset.as_view(), name='me'),
+    path('users/<str:username>/', PublicUserViewset.as_view(), name='public-users-list'),
+    path('users/<str:username>/follow/', follow_user, name='follow-user'),
+    path('users/<str:username>/unfollow/', unfollow_user, name='unfollow-user')
 ]

--- a/userdata/views.py
+++ b/userdata/views.py
@@ -1,3 +1,0 @@
-from django.shortcuts import render
-
-# Create your views here.

--- a/userdata/viewsets/__init__.py
+++ b/userdata/viewsets/__init__.py
@@ -1,2 +1,3 @@
 from .register_viewset import RegisterUsers
 from .me_viewset import MeViewset
+from .public_user_viewset import PublicUserViewset

--- a/userdata/viewsets/follow.py
+++ b/userdata/viewsets/follow.py
@@ -1,0 +1,42 @@
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework import status
+from django.contrib.auth import get_user_model
+from ..models import Profile
+
+User = get_user_model()
+
+
+@api_view(['POST'])
+@permission_classes([IsAuthenticated])
+def follow_user(request, username):
+    try:
+        me = request.user.profile
+        target = Profile.objects.get(user__username=username)
+
+        if me == target:
+            return Response({'error': 'Você não pode seguir você mesmo.'}, status=status.HTTP_400_BAD_REQUEST)
+
+        me.following.add(target)
+        return Response({'success': f'Seguindo {username}'}, status=status.HTTP_200_OK)
+
+    except Profile.DoesNotExist:
+        return Response({'error': 'Usuário não encontrado.'}, status=status.HTTP_404_NOT_FOUND)
+
+
+@api_view(['POST'])
+@permission_classes([IsAuthenticated])
+def unfollow_user(request, username):
+    try:
+        me = request.user.profile
+        target = Profile.objects.get(user__username=username)
+
+        if me == target:
+            return Response({'error': 'Você não pode deixar de seguir a si mesmo.'}, status=status.HTTP_400_BAD_REQUEST)
+
+        me.following.remove(target)
+        return Response({'success': f'Parou de seguir {username}.'}, status=status.HTTP_200_OK)
+
+    except Profile.DoesNotExist:
+        return Response({'error': 'Usuário não encontrado.'}, status=status.HTTP_404_NOT_FOUND)

--- a/userdata/viewsets/me_viewset.py
+++ b/userdata/viewsets/me_viewset.py
@@ -1,12 +1,11 @@
-from rest_framework.views import APIView
-from rest_framework.response import Response
+from rest_framework.generics import RetrieveUpdateAPIView
 from rest_framework.permissions import IsAuthenticated
 from ..serializers import UserSerializer
 
 
-class MeViewset(APIView):
+class MeViewset(RetrieveUpdateAPIView):
     permission_classes = [IsAuthenticated]
+    serializer_class = UserSerializer
 
-    def get(self, request):
-        serializer = UserSerializer(request.user)
-        return Response(serializer.data)
+    def get_object(self):
+        return self.request.user

--- a/userdata/viewsets/public_user_viewset.py
+++ b/userdata/viewsets/public_user_viewset.py
@@ -1,0 +1,12 @@
+from rest_framework import generics, permissions
+from django.contrib.auth import get_user_model
+from ..serializers import PublicUserSerializer
+
+User = get_user_model()
+
+
+class PublicUserViewset(generics.RetrieveAPIView):
+    queryset = User.objects.all()
+    serializer_class = PublicUserSerializer
+    permission_classes = [permissions.AllowAny]
+    lookup_field = 'username'


### PR DESCRIPTION
## Feats:
- Novo model `Profile`, para armazenar os dados correspondentes ao perfil do usuário, como: avatar, nome de exibição, followers, quem está seguindo, etc...
- Novo serializer `PublicUserSerializer`, para aninhar o serializer de `Profile`, exibindo apenas o username, seguido dos dados públicos:
![image](https://github.com/user-attachments/assets/03a28b21-50a0-4ff1-b7c3-5530b7aae2b7)
- Nova viewset `follow`, contendo duas views: `follow_user` e `unfollow_user`, protegidas com simplejwt para adicionar ou remover um novo seguidor através de um `POST`.
Como usar:
  - Endpoints: `/api/users/nome_do_user/` seguidos de `follow/` ou `unfollow/`.
  - Método `POST`.
  - Testando: 
      curl -X POST http://.../api/users/`username_aqui`/follow/ -H "Authorization: Bearer `token_access_aqui`"